### PR TITLE
Add return null if POI is not found in getPoi

### DIFF
--- a/packages/adsum-utils/services/ClientAPI.js
+++ b/packages/adsum-utils/services/ClientAPI.js
@@ -30,9 +30,7 @@ class ClientAPI {
     getPoi(id) {
         let poi = this.entityManager.getRepository('Poi').get(id);
 
-        if (poi === null) return null;
-
-        if (poi.logos && poi.logos.values) {
+        if (poi && poi.logos && poi.logos.values) {
             for (const logo in poi.logos.values) {
                 if (poi.logos.values[logo] && poi.logos.values[logo].value && !isNaN(poi.logos.values[logo].value)) {
                     poi.logos.values[logo] = this.getFile(poi.logos.values[logo].value);

--- a/packages/adsum-utils/services/ClientAPI.js
+++ b/packages/adsum-utils/services/ClientAPI.js
@@ -30,6 +30,8 @@ class ClientAPI {
     getPoi(id) {
         let poi = this.entityManager.getRepository('Poi').get(id);
 
+        if (poi === null) return null;
+
         if (poi.logos && poi.logos.values) {
             for (const logo in poi.logos.values) {
                 if (poi.logos.values[logo] && poi.logos.values[logo].value && !isNaN(poi.logos.values[logo].value)) {


### PR DESCRIPTION
Add return null if POI is not found in getPoi method of ClientAPI. 
This way, we are able to test if a given ID correspond to a POI or not.
Furthermore, we no longer have an error when calling for poi.logos inside getPoi when poi is not found.